### PR TITLE
Expose commands to control RecentFilesView selection

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,7 +14,9 @@ module.exports =
       @createRecentFiles(state).setMaxFilesToRemember(val)
 
     atom.commands.add 'atom-workspace', {
-      'recent-files-fuzzy-finder:toggle-finder': => @createRecentFilesView().toggle()
+      'recent-files-fuzzy-finder:toggle-finder': => 
+        @createRecentFilesView().toggle()
+        @createRecentFilesView().list.scrollToTop()
       'recent-files-fuzzy-finder:remove-closed-files': => @recentFiles.removeClosed()
       'recent-files-fuzzy-finder:select-next-item': => @createRecentFilesView().selectNextItemView()
       'recent-files-fuzzy-finder:confirm-selection': => @createRecentFilesView().confirmSelection()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,6 +16,8 @@ module.exports =
     atom.commands.add 'atom-workspace', {
       'recent-files-fuzzy-finder:toggle-finder': => @createRecentFilesView().toggle()
       'recent-files-fuzzy-finder:remove-closed-files': => @recentFiles.removeClosed()
+      'recent-files-fuzzy-finder:select-next-item': => @createRecentFilesView().selectNextItemView()
+      'recent-files-fuzzy-finder:confirm-selection': => @createRecentFilesView().confirmSelection()
     }
 
   createRecentFiles: (state) ->

--- a/lib/recent-files-view.coffee
+++ b/lib/recent-files-view.coffee
@@ -6,6 +6,8 @@ module.exports =
 class RecentFilesView extends FuzzyFinderView
   initialize: (@recentFiles) ->
     super
+    
+    @addClass('recent-files-fuzzy-finder')
 
   toggle: ->
     if @panel?.isVisible()


### PR DESCRIPTION
This pull request exposes `selectNextItemView()` and `confirmSelection()` of  `RecentFilesView` commands to control `RecentFilesView` selection, to make this package more configurable
For example i want to configure switching between recent files with just one key shortcut (`ctrl-tab`, like in NetBeans), this is keymap.cson example for this configuration

```cson
'atom-workspace':
  'ctrl-tab': 'recent-files-fuzzy-finder:toggle-finder'
  'ctrl-tab ^ctrl': 'unset!'
'.recent-files-fuzzy-finder':
  'ctrl-tab': 'recent-files-fuzzy-finder:select-next-item'
  'ctrl-escape': 'recent-files-fuzzy-finder:toggle-finder'
  '^ctrl': 'recent-files-fuzzy-finder:confirm-selection'
```

I have also added .recent-files-fuzzy-finder class to the RecentFilesView, to manage keymaps only for it