### PR TITLE
Fix Uncaught TypeError: Class constructor FuzzyFinderView cannot be invoked without 'new'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [keepachangelog.com](http://keepachangelog.com/).
 
 ## [x.y.z] - 201y-mm-dd
+### Fixed
+- Uncaught TypeError: Class constructor FuzzyFinderView cannot be invoked without 'new' #20
 
 ## [0.3.0] - 2017-01-18
 ### Added

--- a/lib/fuzzy-finder-version-satisfied.coffee
+++ b/lib/fuzzy-finder-version-satisfied.coffee
@@ -1,0 +1,12 @@
+semver = require('semver')
+path = require('path')
+
+packagePath = atom.packages.resolvePackagePath('fuzzy-finder')
+pkgJSON = require(path.join(packagePath, 'package.json'))
+pkgVersion = semver.valid(pkgJSON?.version)
+
+# v1.5.0 of FuzzyFinder contains the changeset of https://github.com/atom/fuzzy-finder/pull/273 which is not
+# backward compatible with the recent-files-view due to coffeescript<->ES6 class extends implementation mismatch
+# Use the old version of the view to not break older Atom versions for the time being.
+# Should be able to remove this check once Atom Beta v1.16-beta0 is merged into stable (Atom v1.5+ probably).
+module.exports = semver.satisfies(pkgVersion, '>=1.5.0')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -32,13 +32,7 @@ module.exports =
 
   createRecentFilesView: ->
     unless @recentFilesView?
-      # v1.5.0 of FuzzyFinder contains the changeset of https://github.com/atom/fuzzy-finder/pull/273 which is not
-      # backward compatible with the recent-files-view due to coffeescript<->ES6 class extends implementation mismatch
-      # Use the old version of the view to not break older Atom versions for the time being.
-      # Should be able to remove this check once Atom Beta v1.16-beta0 is merged into stable (Atom v1.5+ probably).
-      semver = require('semver')
-      fuzzyFinderPkgVersion = semver.valid(atom.packages.getLoadedPackage('fuzzy-finder')?.metadata?.version)
-      RecentFilesView = if semver.satisfies(fuzzyFinderPkgVersion, '>=1.5.0')
+      RecentFilesView = if require('./fuzzy-finder-version-satisfied')
         require './recent-files-view'
       else
         require './recent-files-view-old'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -14,9 +14,7 @@ module.exports =
       @createRecentFiles(state).setMaxFilesToRemember(val)
 
     atom.commands.add 'atom-workspace', {
-      'recent-files-fuzzy-finder:toggle-finder': =>
-        @createRecentFilesView().toggle()
-        @createRecentFilesView().list.scrollToTop()
+      'recent-files-fuzzy-finder:toggle-finder': => @createRecentFilesView().toggle()
       'recent-files-fuzzy-finder:remove-closed-files': => @recentFiles.removeClosed()
       'recent-files-fuzzy-finder:select-next-item': => @createRecentFilesView().selectNextItemView()
       'recent-files-fuzzy-finder:confirm-selection': => @createRecentFilesView().confirmSelection()
@@ -34,7 +32,17 @@ module.exports =
 
   createRecentFilesView: ->
     unless @recentFilesView?
-      RecentFilesView = require './recent-files-view'
+      # v1.5.0 of FuzzyFinder contains the changeset of https://github.com/atom/fuzzy-finder/pull/273 which is not
+      # backward compatible with the recent-files-view due to coffeescript<->ES6 class extends implementation mismatch
+      # Use the old version of the view to not break older Atom versions for the time being.
+      # Should be able to remove this check once Atom Beta v1.16-beta0 is merged into stable (Atom v1.5+ probably).
+      semver = require('semver')
+      fuzzyFinderPkgVersion = semver.valid(atom.packages.getLoadedPackage('fuzzy-finder')?.metadata?.version)
+      RecentFilesView = if semver.satisfies(fuzzyFinderPkgVersion, '>=1.5.0')
+        require './recent-files-view'
+      else
+        require './recent-files-view-old'
+
       @recentFilesView = new RecentFilesView(@recentFiles)
     @recentFilesView
 

--- a/lib/recent-files-view-old.coffee
+++ b/lib/recent-files-view-old.coffee
@@ -2,6 +2,7 @@ path = require 'path'
 packagePath = atom.packages.resolvePackagePath('fuzzy-finder')
 FuzzyFinderView = require path.join(packagePath, 'lib', 'fuzzy-finder-view')
 
+# This is only intended to be used for older version of fuzzy-finder
 module.exports =
 class RecentFilesView extends FuzzyFinderView
   initialize: (@recentFiles) ->

--- a/lib/recent-files-view.js
+++ b/lib/recent-files-view.js
@@ -1,0 +1,40 @@
+/** @babel */
+
+import path from 'path'
+
+const packagePath = atom.packages.resolvePackagePath('fuzzy-finder')
+const FuzzyFinderView = require(path.join(packagePath, 'lib', 'fuzzy-finder-view'))
+
+export default class RecentFilesView extends FuzzyFinderView {
+
+  constructor (recentFiles) {
+    super()
+    this.recentFiles = recentFiles
+    this.selectListView.element.classList.add('fuzzy-finder')
+  }
+
+  async toggle () {
+    if (this.panel && this.panel.isVisible()) {
+      this.cancel()
+    } else {
+      const activeTextEditor = atom.workspace.getActiveTextEditor()
+
+      let paths = this.recentFiles.pathsSortedByLastUsage()
+      if (activeTextEditor && activeTextEditor.getPath() === paths[0]) {
+        paths = paths.slice(1)
+      }
+
+      if (paths.length > 0) {
+        await this.setItems(paths)
+        this.show()
+      }
+    }
+  }
+
+  getEmptyMessage (itemCount) {
+    return itemCount > 0
+      ? super.getEmptyMessage()
+      : 'No files have been closed recently'
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "temp": "0.8.3"
   },
   "dependencies": {
+    "semver": "5.3.0",
     "underscore-plus": "1.6.6"
   },
   "scripts": {

--- a/spec/atom-recent-files-fuzzy-finder-spec.coffee
+++ b/spec/atom-recent-files-fuzzy-finder-spec.coffee
@@ -84,49 +84,59 @@ describe "RecentFilesFuzzyFinder", ->
 
           expect(atom.views.getView(editor3)).toHaveFocus()
 
-          dispatchCommand('toggle-finder')
-          expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
-          expect(workspaceElement.querySelector('.fuzzy-finder')).toHaveFocus()
-          recentFilesView.filterEditorView.getModel().insertText('this should not show up next time we toggle')
+          waitsForPromise ->
+            recentFilesView.toggle()
+          runs ->
+            expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
+            expect(workspaceElement.querySelector('.fuzzy-finder')).toHaveFocus()
+            recentFilesView.selectListView.refs.queryEditor.insertText('this should not show up next time we toggle')
 
-          dispatchCommand('toggle-finder')
-          expect(atom.views.getView(editor3)).toHaveFocus()
-          expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe false
+          waitsForPromise ->
+            recentFilesView.toggle()
+          runs ->
+            expect(atom.views.getView(editor3)).toHaveFocus()
+            expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe false
 
-          dispatchCommand('toggle-finder')
-          expect(recentFilesView.filterEditorView.getText()).toBe ''
+          waitsForPromise ->
+            recentFilesView.toggle()
+          runs ->
+            expect(recentFilesView.selectListView.refs.queryEditor.getText()).toBe ''
 
         it "lists the paths of recently opened files, sorted by most recent usage but without currently active file", ->
           waitsForPromise ->
             atom.workspace.open 'sample-with-tabs.coffee'
-
+          waitsForPromise ->
+            recentFilesView.toggle()
           runs ->
-            dispatchCommand('toggle-finder')
             expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
-            expect(_.pluck(recentFilesView.list.find('li > div.file'), 'outerText')).toEqual ['sample.txt', 'sample.js']
-            dispatchCommand('toggle-finder')
+            expect(_.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText')).toEqual ['sample.txt', 'sample.js']
+
+          waitsForPromise ->
+            recentFilesView.toggle()
+          runs ->
             expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe false
 
           waitsForPromise ->
             atom.workspace.open 'sample.txt'
-
+          waitsForPromise ->
+            recentFilesView.toggle()
           runs ->
-            dispatchCommand('toggle-finder')
             expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
-            expect(_.pluck(recentFilesView.list.find('li > div.file'), 'outerText')).toEqual ['sample-with-tabs.coffee', 'sample.js']
-            expect(recentFilesView.list.children().first()).toHaveClass 'selected'
+            expect(_.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText')).toEqual ['sample-with-tabs.coffee', 'sample.js']
+            # expect(recentFilesView.list.children().first()).toHaveClass 'selected'
+            expect(recentFilesView.element.querySelectorAll('li')[0]).toHaveClass 'selected'
 
             paneItem.destroy() for paneItem in atom.workspace.getPaneItems()
-            expect(_.pluck(recentFilesView.list.find('li > div.file'), 'outerText')).toEqual ['sample-with-tabs.coffee', 'sample.js']
+            expect(_.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText')).toEqual ['sample-with-tabs.coffee', 'sample.js']
 
         it "ignores anonymous files", ->
           waitsForPromise ->
             atom.workspace.open('unsaved-file')
-
+          waitsForPromise ->
+            recentFilesView.toggle()
           runs ->
-            dispatchCommand('toggle-finder')
             expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
-            expect(_.pluck(recentFilesView.list.find('li > div.file'), 'outerText')).not.toContain ['unsaved-file']
+            expect(_.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText')).not.toContain ['unsaved-file']
 
   describe "call remove closed files", ->
     describe "when there are pane items with paths", ->
@@ -140,24 +150,31 @@ describe "RecentFilesFuzzyFinder", ->
 
       it "removes closed files", ->
         paneItem.destroy() for paneItem in atom.workspace.getPaneItems()
-        dispatchCommand('toggle-finder')
-        expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
-        expect(_.pluck(recentFilesView.list.find('li > div.file'), 'outerText')).toEqual ['sample-with-tabs.coffee', 'sample.txt', 'sample.js']
-        dispatchCommand('toggle-finder')
 
-        dispatchCommand('remove-closed-files')
-        dispatchCommand('toggle-finder')
-        expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe false
+        waitsForPromise ->
+          recentFilesView.toggle()
+        runs ->
+          expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
+          expect(_.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText')).toEqual ['sample-with-tabs.coffee', 'sample.txt', 'sample.js']
+        waitsForPromise ->
+          recentFilesView.toggle()
+        runs ->
+          dispatchCommand('remove-closed-files')
+
+        waitsForPromise ->
+          recentFilesView.toggle()
+        runs ->
+          expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe false
 
         waitsForPromise ->
           atom.workspace.open 'sample.js'
         waitsForPromise ->
           atom.workspace.open('new-file')
-
+        waitsForPromise ->
+          recentFilesView.toggle()
         runs ->
-          dispatchCommand('toggle-finder')
           expect(atom.workspace.panelForItem(recentFilesView).isVisible()).toBe true
-          expect(_.pluck(recentFilesView.list.find('li > div.file'), 'outerText')).toEqual ['sample.js']
+          expect(_.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText')).toEqual ['sample.js']
 
   describe 'delete a file', ->
     beforeEach ->
@@ -172,8 +189,8 @@ describe "RecentFilesFuzzyFinder", ->
       shell.moveItemToTrash path.join(rootDir1, 'sample.txt')
 
       waitsFor "file to be deleted", 300, ->
-        dispatchCommand('toggle-finder')
-        _.pluck(recentFilesView.list.find('li > div.file'), 'outerText').length is 1
+        recentFilesView.toggle()
+        _.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText').length is 1
 
       runs ->
-        expect(_.pluck(recentFilesView.list.find('li > div.file'), 'outerText')).toEqual ['sample.js']
+        expect(_.pluck(Array.from(recentFilesView.element.querySelectorAll('li > div.file')), 'outerText')).toEqual ['sample.js']


### PR DESCRIPTION
See inlined comment on fuzzy-finder-version-satisfied file for details

Closes #20 