### PR TITLE
Make selection operations: select-next-item and confirm-selection work again

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,4 @@
+isNewFuzzyFinder = require('./fuzzy-finder-version-satisfied');
 module.exports =
   config:
     maxFilesToRemember:
@@ -16,8 +17,8 @@ module.exports =
     atom.commands.add 'atom-workspace', {
       'recent-files-fuzzy-finder:toggle-finder': => @createRecentFilesView().toggle()
       'recent-files-fuzzy-finder:remove-closed-files': => @recentFiles.removeClosed()
-      'recent-files-fuzzy-finder:select-next-item': => @createRecentFilesView().selectListView.selectNext()
-      'recent-files-fuzzy-finder:confirm-selection': => @createRecentFilesView().selectListView.confirmSelection()
+      'recent-files-fuzzy-finder:select-next-item': => if isNewFuzzyFinder then @createRecentFilesView().selectListView.selectNext() else @createRecentFilesView().selectNextItemView()
+      'recent-files-fuzzy-finder:confirm-selection': => if isNewFuzzyFinder then @createRecentFilesView().selectListView.confirmSelection() else @createRecentFilesView().confirmSelection()
     }
 
   createRecentFiles: (state) ->
@@ -32,7 +33,7 @@ module.exports =
 
   createRecentFilesView: ->
     unless @recentFilesView?
-      RecentFilesView = if require('./fuzzy-finder-version-satisfied')
+      RecentFilesView = if isNewFuzzyFinder
         require './recent-files-view'
       else
         require './recent-files-view-old'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,4 @@
-isNewFuzzyFinder = require('./fuzzy-finder-version-satisfied');
+isNewFuzzyFinder = require('./fuzzy-finder-version-satisfied')
 module.exports =
   config:
     maxFilesToRemember:

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,8 +16,8 @@ module.exports =
     atom.commands.add 'atom-workspace', {
       'recent-files-fuzzy-finder:toggle-finder': => @createRecentFilesView().toggle()
       'recent-files-fuzzy-finder:remove-closed-files': => @recentFiles.removeClosed()
-      'recent-files-fuzzy-finder:select-next-item': => @createRecentFilesView().selectNextItemView()
-      'recent-files-fuzzy-finder:confirm-selection': => @createRecentFilesView().confirmSelection()
+      'recent-files-fuzzy-finder:select-next-item': => @createRecentFilesView().selectListView.selectNext()
+      'recent-files-fuzzy-finder:confirm-selection': => @createRecentFilesView().selectListView.confirmSelection()
     }
 
   createRecentFiles: (state) ->

--- a/lib/recent-files-view.js
+++ b/lib/recent-files-view.js
@@ -10,7 +10,7 @@ export default class RecentFilesView extends FuzzyFinderView {
   constructor (recentFiles) {
     super()
     this.recentFiles = recentFiles
-    this.selectListView.element.classList.add('fuzzy-finder')
+    this.selectListView.element.classList.add('fuzzy-finder', 'recent-files-fuzzy-finder')
   }
 
   async toggle () {


### PR DESCRIPTION
fix to match changes that happened in v1.5.1 of fuzzy-finder https://github.com/atom/fuzzy-finder/tree/v1.5.1